### PR TITLE
Remove Recursive Generics

### DIFF
--- a/src/main/java/io/r2dbc/adba/AdbaConnection.java
+++ b/src/main/java/io/r2dbc/adba/AdbaConnection.java
@@ -68,7 +68,7 @@ class AdbaConnection implements Connection {
     }
 
     @Override
-    public Batch<?> createBatch() {
+    public Batch createBatch() {
         throw new UnsupportedOperationException();
     }
 

--- a/src/main/java/io/r2dbc/adba/AdbaStatement.java
+++ b/src/main/java/io/r2dbc/adba/AdbaStatement.java
@@ -49,7 +49,7 @@ import static jdk.incubator.sql2.Result.RowCount;
  *
  * @author Mark Paluch
  */
-class AdbaStatement implements Statement<AdbaStatement> {
+class AdbaStatement implements Statement {
 
     private final Bindings bindings = new Bindings();
 


### PR DESCRIPTION
This change removes the recursive generics from this implementation to be compliant with changes made to the SPI.  These changes were driven by the observation that recursive generics made consumption of the API harder and no longer provided us much value.

[r2dbc/r2dbc-spi#24]

Signed-off-by: Ben Hale <bhale@pivotal.io>