### PR TITLE
URL Cleanup

### DIFF
--- a/src/main/java/io/r2dbc/adba/Assert.java
+++ b/src/main/java/io/r2dbc/adba/Assert.java
@@ -40,7 +40,7 @@ import java.util.function.Supplier;
  * </pre>
  * <p>
  * Mainly for internal use within the framework; consider
- * <a href="http://commons.apache.org/proper/commons-lang/">Apache's Commons Lang</a> for a more comprehensive suite of
+ * <a href="https://commons.apache.org/proper/commons-lang/">Apache's Commons Lang</a> for a more comprehensive suite of
  * {@code String} utilities. Imported from Spring Framework.
  */
 abstract class Assert {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://commons.apache.org/proper/commons-lang/ with 1 occurrences migrated to:  
  https://commons.apache.org/proper/commons-lang/ ([https](https://commons.apache.org/proper/commons-lang/) result 200).